### PR TITLE
Compile errors on esp32

### DIFF
--- a/LT8920.cpp
+++ b/LT8920.cpp
@@ -1,6 +1,10 @@
 #include <SPI.h>
 #include "LT8920.h"
 
+#ifndef _BV
+#  define _BV(bit) (1 << (bit))
+#endif
+
 #define REGISTER_READ       0b10000000  //bin
 #define REGISTER_WRITE      0b00000000  //bin
 #define REGISTER_MASK       0b01111111  //bin

--- a/LT8920.cpp
+++ b/LT8920.cpp
@@ -189,6 +189,7 @@ LT8920::DataRate LT8920::getDataRate()
     case DATARATE_62KBPS:
       return LT8920_62KBPS;
   }
+  return LT8920_UNDEFINED;
 }
 
 uint16_t LT8920::readRegister(uint8_t reg)

--- a/LT8920.h
+++ b/LT8920.h
@@ -9,6 +9,8 @@
 #ifndef LT8920_H
 #define LT8920_H
 
+#include "Arduino.h"  // for Stream
+
 class LT8920
 {
 
@@ -20,7 +22,8 @@ class LT8920
       LT8920_1MBPS,     /** default transmit rate */
       LT8920_250KBPS,   /** 250 Kpbs, only on lt8910 */
       LT8920_125KBPS,   /** 125 Kbps, only on lt8910 */
-      LT8920_62KBPS     /** 62 Kbps, only on lt8910 */
+      LT8920_62KBPS,     /** 62 Kbps, only on lt8910 */
+      LT8920_UNDEFINED  /** Error */
     };
 
   private:


### PR DESCRIPTION
The header file is using Stream w/o importing Arduino.h.
This is leading to compile errors e.g. for the ESP32.
In addition you can not assume that the _BV macro is available in all environments: e.g. it is missing in the RP2040

This should also address [this issue](https://github.com/mengguang/LT8920/issues/3)!